### PR TITLE
Change render from parameter to unix timestamp

### DIFF
--- a/library/Perfdatagraphsgraphite/Client/Graphite.php
+++ b/library/Perfdatagraphsgraphite/Client/Graphite.php
@@ -205,7 +205,7 @@ class Graphite
         // Subtract the inverval from the current time so that we have
         // the 'from' parameter for graphite
         $now->sub($int);
-        return $now->format('H:i_Ymd');
+        return $now->getTimestamp();
     }
 
     /**


### PR DESCRIPTION
- The Victoriametrics Graphite API cannot handle the format HH:MM_YYMMDD

Fixes #1 